### PR TITLE
Rename binary to fab-3

### DIFF
--- a/examples/EVM_Smart_Contracts.md
+++ b/examples/EVM_Smart_Contracts.md
@@ -156,12 +156,12 @@ Set the required variables before running the proxy.
 The proxy can be built like other go projects. Make sure you are at the root of this repo and the repo is in your gopath.
 
 ```bash
-  go build -o fab3 ./fab3/cmd
+  go build -o fab-3 ./fab3/cmd
 ```
-You should see a binary `fab3`. If you have set the required environment variables you can run the proxy by
+You should see a binary `fab-3`. If you have set the required environment variables you can run the proxy by
 
 ```bash
-  ./fab3
+  ./fab-3
 ```
 You should see output like `Starting Fab Proxy on port 5000` if you used the default port.
 


### PR DESCRIPTION
Without the change, there will be an error: build output "fab3" already exists and is a directory.

Another option is to change the folder name ./fab3 to something else. What is preferred?