### PR TITLE
FAB-16697 remove linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ unit-tests: unit-test
 dev-test:
 	ginkgo watch -notify -randomizeAllSpecs -requireSuite -race -cover -skipPackage integration -r
 
-linter: gotool.goimports gotool.golint check-deps
+linter: gotool.goimports check-deps
 	@echo "LINT: Running code checks.."
 	@scripts/golinter.sh
 

--- a/gotools.mk
+++ b/gotools.mk
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-GOTOOLS = counterfeiter dep golint goimports ginkgo misspell
+GOTOOLS = counterfeiter dep goimports ginkgo misspell
 BUILD_DIR ?= .build
 GOTOOLS_GOPATH ?= $(BUILD_DIR)/gotools
 GOTOOLS_BINDIR ?= $(firstword $(subst :, ,$(GOPATH)))/bin
@@ -12,7 +12,6 @@ GOROOT ?= $(firstword $(subst :, ,$(GOPATH))
 # go tool->path mapping
 go.fqp.counterfeiter := github.com/maxbrunsfeld/counterfeiter
 go.fqp.goimports     := golang.org/x/tools/cmd/goimports
-go.fqp.golint        := golang.org/x/lint/golint
 go.fqp.misspell      := github.com/client9/misspell/cmd/misspell
 
 .PHONY: gotools-install

--- a/scripts/golinter.sh
+++ b/scripts/golinter.sh
@@ -13,38 +13,22 @@ declare -a arr=(
 "./statemanager"
 )
 
-# place the Go build cache directory into the default build tree if it exists
-if [ -d "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-evm/.build" ]; then
-    export GOCACHE="${GOPATH}/src/github.com/hyperledger/fabric-chaincode-evm/.build/go-cache"
-fi
-
 for i in "${arr[@]}"
 do
-    echo ">>>Checking code under $i/"
-
-    echo "Checking with gofmt"
-    OUTPUT="$(gofmt -l -s ./$i | grep -v testdata/ || true)"
-    if [[ $OUTPUT ]]; then
-        echo "The following files contain gofmt errors"
-        echo "$OUTPUT"
-        echo "The gofmt command 'gofmt -l -s -w' must be run for these files"
-        exit 1
-    fi
-
-    echo "Checking with goimports"
-    OUTPUT="$(goimports -l $i | grep -v testdata/ || true )"
+    echo ">>>Checking code under $i/ with goimports"
+    OUTPUT="$(goimports -l ./$i || true )"
     if [[ $OUTPUT ]]; then
         echo "The following files contain goimports errors"
         echo $OUTPUT
         echo "The goimports command 'goimports -l -w' must be run for these files"
         exit 1
     fi
-
-    echo "Checking with go vet"
-    OUTPUT="$(go vet -composites=false $i/...)"
-    if [[ $OUTPUT ]]; then
-        echo "The following files contain go vet errors"
-        echo $OUTPUT
-        exit 1
-    fi
 done
+
+echo "Checking with go vet"
+OUTPUT="$(go vet ./...)"
+if [[ $OUTPUT ]]; then
+    echo "The following files contain go vet errors"
+    echo $OUTPUT
+    exit 1
+fi


### PR DESCRIPTION
go lint is not run. Remove go lint.

go fmt and goimports do the same thing. goimports is more powerful due
to import reordering, so rely only on goimports. Remove go fmt.

The build cache is not the build cache we use for building a binary,
so we end up building everything multiple times instead of using the
cache. Remove the cache definition.

go vet is intelligent and ignores the vendor directory on it's
own. Take it out of the loop and invoke it once at the top level.

Change-Id: Ieb057298f6ecd83b67607de29c24572a4c35018a
Signed-off-by: Morgan Bauer <mbauer@us.ibm.com>