### PR TITLE
FAB-16727 Fix address case sensitivity

### DIFF
--- a/fab3/ethservice.go
+++ b/fab3/ethservice.go
@@ -727,7 +727,7 @@ LOG_EVENT:
 			// if no address, empty range, skipped, present but empty address field results in no match
 			for _, address := range af {
 				logger.Debugw("trying address match", "matcherAddress", address, "eventAddress", logEvent.Address)
-				if logEvent.Address == address {
+				if logEvent.Address == strings.ToLower(address) {
 					foundMatch = true
 					break
 				}


### PR DESCRIPTION
Addresses can now be matched regardless of case in parsing logs.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>

Thank you for contributing to the `fabric-chaincode-evm` project!
Please look at our [Contributions Docs](../README.md#Contributions) and make
sure you have done the following before submitting:

* [ ] Ran the basic checks: `make basic-checks`
* [ ] Ran the unit tests: `make unit-test`
* [ ] Ran the integration tests: `make integration-test`
* [x] Added the associated JIRA ticket number in the commit message title
* [x] Link to the JIRA Ticket: https://jira.hyperledger.org/browse/FAB-16727

If you do not have a corresponding JIRA ticket, please open one in the [Fabric
JIRA](https://jira.hyperledger.org/projects/FAB/issues) and add
`fabric-chaincode-evm` as the component. In the JIRA ticket, include use
cases, design and other information useful to understanding why you are making
this pull request.

If you have any questions please feel free to ask in the #fabric-evm channel
on the [Hyperledger Chat](https://chat.hyperledger.org/channel/fabric-evm).

Thanks again for your contribution!
