### PR TITLE
[FAB-16727] Lowercase address in filters

### DIFF
--- a/fab3/types/types.go
+++ b/fab3/types/types.go
@@ -154,7 +154,7 @@ func NewAddressFilter(s string) (AddressFilter, error) {
 	if len(s) != HexEncodedAddressLegnth {
 		return nil, fmt.Errorf("address in wrong format, need 40 chars prefixed with '0x', got %d chars for %q", len(s), s)
 	}
-	return AddressFilter{s}, nil
+	return AddressFilter{strings.ToLower(s)}, nil
 }
 
 // NewTopicFilter takes a string and checks that is the correct length to

--- a/fab3/types/types_test.go
+++ b/fab3/types/types_test.go
@@ -85,6 +85,16 @@ var _ = Describe("Types JSON Marshaling and Unmarshaling", func() {
 			Entry("slack validation of multiple address in array",
 				[]byte(`{"address":["3832333733343538313634383230393437383931","3832333733343538313634383230393437383932"]}`),
 				valid{"", "", []string{"3832333733343538313634383230393437383931", "3832333733343538313634383230393437383932"}, nil}),
+			// all addresses are lowered cased
+			Entry("mixed case single addresses",
+				[]byte(`{"address":"0x38323337333435383136343832303934373839aA"}`),
+				valid{"", "", []string{"38323337333435383136343832303934373839aa"}, nil}),
+			Entry("mixed cases single address in array",
+				[]byte(`{"address":["0x38323337333435383136343832303934373839bB"]}`),
+				valid{"", "", []string{"38323337333435383136343832303934373839bb"}, nil}),
+			Entry("mixed cases multiple address in array",
+				[]byte(`{"address":["0x38323337333435383136343832303934373839aA","0x38323337333435383136343832303934373839bB"]}`),
+				valid{"", "", []string{"38323337333435383136343832303934373839aa", "38323337333435383136343832303934373839bb"}, nil}),
 			// topics
 			Entry("any topic",
 				[]byte(`{"topics":[]}`),


### PR DESCRIPTION
 - To ensure case insensitive matching and since addresses from evmcc
 are always lowercase, store incoming address filters lowercase as well

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>

Thank you for contributing to the `fabric-chaincode-evm` project!
Please look at our [Contributions Docs](../README.md#Contributions) and make
sure you have done the following before submitting:

* [x] Ran the basic checks: `make basic-checks`
* [x] Ran the unit tests: `make unit-test`
* [x] Ran the integration tests: `make integration-test`
* [x] Added the associated JIRA ticket number in the commit message title
* [x] Link to the JIRA Ticket: https://jira.hyperledger.org/browse/FAB-16727

If you do not have a corresponding JIRA ticket, please open one in the [Fabric
JIRA](https://jira.hyperledger.org/projects/FAB/issues) and add
`fabric-chaincode-evm` as the component. In the JIRA ticket, include use
cases, design and other information useful to understanding why you are making
this pull request.

If you have any questions please feel free to ask in the #fabric-evm channel
on the [Hyperledger Chat](https://chat.hyperledger.org/channel/fabric-evm).

Thanks again for your contribution!
