### PR TITLE
FABCE-145 update README for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## v0.4.0
+Fri Dec 20 16:24:29 PST 2019
+
+* [361ed2d](https://github.com/hyperledger/fabric-chaincode-evm/commit/361ed2d) [FABCE-145](https://jira.hyperledger.org/browse/FABCE-145) update README for 0.4.0 release
+* [bf3fbd5](https://github.com/hyperledger/fabric-chaincode-evm/commit/bf3fbd5) [FAB-16919](https://jira.hyperledger.org/browse/FAB-16919) Remove scripts/goListFiles.sh
+* [0ed01b6](https://github.com/hyperledger/fabric-chaincode-evm/commit/0ed01b6) [FAB-17053](https://jira.hyperledger.org/browse/FAB-17053) Switch Fab3 and Integration to Go Mod
+* [0476cc1](https://github.com/hyperledger/fabric-chaincode-evm/commit/0476cc1) [FAB-17053](https://jira.hyperledger.org/browse/FAB-17053) Switch EVMCC to go modules
+* [3dae2db](https://github.com/hyperledger/fabric-chaincode-evm/commit/3dae2db) [FAB-16918](https://jira.hyperledger.org/browse/FAB-16918) Restructure evmcc directory
+* [b1cdfe0](https://github.com/hyperledger/fabric-chaincode-evm/commit/b1cdfe0) [FAB-16620](https://jira.hyperledger.org/browse/FAB-16620) HexEncode Event Name for contract create
+* [8378f2f](https://github.com/hyperledger/fabric-chaincode-evm/commit/8378f2f) [FAB-16727](https://jira.hyperledger.org/browse/FAB-16727) Lowercase address in filters
+* [5ce150c](https://github.com/hyperledger/fabric-chaincode-evm/commit/5ce150c) [FAB-16693](https://jira.hyperledger.org/browse/FAB-16693) Add Github PR Template
+* [e327cab](https://github.com/hyperledger/fabric-chaincode-evm/commit/e327cab) Add default SECURITY policy
+* [c8d208e](https://github.com/hyperledger/fabric-chaincode-evm/commit/c8d208e) [FAB-16697](https://jira.hyperledger.org/browse/FAB-16697) remove linters
+* [c19796e](https://github.com/hyperledger/fabric-chaincode-evm/commit/c19796e) [FAB-16677](https://jira.hyperledger.org/browse/FAB-16677) Update Contributions Instructions
+* [a697b37](https://github.com/hyperledger/fabric-chaincode-evm/commit/a697b37) [FAB-16692](https://jira.hyperledger.org/browse/FAB-16692) Remove jenkins pipeline files
+* [5df7e55](https://github.com/hyperledger/fabric-chaincode-evm/commit/5df7e55) [FAB-16683](https://jira.hyperledger.org/browse/FAB-16683) Create AZP YAML File
+* [1c384c4](https://github.com/hyperledger/fabric-chaincode-evm/commit/1c384c4) De-fang stalebot
+* [efde49b](https://github.com/hyperledger/fabric-chaincode-evm/commit/efde49b) [FAB-15233](https://jira.hyperledger.org/browse/FAB-15233) add gasLimit to block return values
+* [0793388](https://github.com/hyperledger/fabric-chaincode-evm/commit/0793388) [FAB-14617](https://jira.hyperledger.org/browse/FAB-14617) GetBlockByNumber omits invalid transactions
+* [d944e0f](https://github.com/hyperledger/fabric-chaincode-evm/commit/d944e0f) [FAB-14067](https://jira.hyperledger.org/browse/FAB-14067) NewFilter & UninstallFilter
+* [89b50d3](https://github.com/hyperledger/fabric-chaincode-evm/commit/89b50d3) [FAB-14651](https://jira.hyperledger.org/browse/FAB-14651) improve fab3 building instructions
+* [6d8e0dd](https://github.com/hyperledger/fabric-chaincode-evm/commit/6d8e0dd) [FAB-16519](https://jira.hyperledger.org/browse/FAB-16519) clean calls existing gotools-clean target
+* [f1b1d8d](https://github.com/hyperledger/fabric-chaincode-evm/commit/f1b1d8d) [FAB-16489](https://jira.hyperledger.org/browse/FAB-16489) Add CODEOWNERS
+* [2c0ce40](https://github.com/hyperledger/fabric-chaincode-evm/commit/2c0ce40) [FAB-16491](https://jira.hyperledger.org/browse/FAB-16491) update dep to 0.5.4
+* [2e9caa1](https://github.com/hyperledger/fabric-chaincode-evm/commit/2e9caa1) [FAB-16433](https://jira.hyperledger.org/browse/FAB-16433) Fix formatting in Fab3 Instructions
+* [a2cb62a](https://github.com/hyperledger/fabric-chaincode-evm/commit/a2cb62a) [FAB-16434](https://jira.hyperledger.org/browse/FAB-16434) Remove ansicolor plugin changes
+
 ## v0.3.0
 Fri Aug  2 11:33:17 PDT 2019
 

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@
 #   - update-mocks - update the counterfeiter test doubles
 #
 FABRIC_RELEASE=1.4
-PREV_VERSION=0.2.0
-BASE_VERSION=0.3.0
+PREV_VERSION=0.3.0
+BASE_VERSION=0.4.0
 
 EXECUTABLES ?= go git curl docker
 K := $(foreach exec,$(EXECUTABLES),\

--- a/release_notes/v0.4.0.md
+++ b/release_notes/v0.4.0.md
@@ -1,0 +1,34 @@
+v0.4.0 Release Notes - December 20, 2019
+========================================
+
+EVM CC
+------
+ - [FAB-16918](https://jira.hyperledger.org/browse/FAB-16918) EVMCC directory
+   was restructured to make building and packaging of the chaincode easier.
+ - [FAB-17053](https://jira.hyperledger.org/browse/FAB-17053) EVMCC is now
+   golang module enabled, but still has a vendor directory to provide support
+   for Fabric v1.4.
+
+Fab3
+----
+ - [FAB-17053](https://jira.hyperledger.org/browse/FAB-17053) Fab3 is now golang
+   module enabled.
+ - [FAB-14067](https://jira.hyperledger.org/browse/FAB-14067) NewFilter &
+   UninstallFilter are added as part of enabling asynchronous
+   filtering. Asynchronous filters are not available for use in this release.
+ - BUGFIX [FAB-16620](https://jira.hyperledger.org/browse/FAB-16620) Ethereum event
+   names are now HexEncoded to ensure that valid UTF-8 bytes are given to the
+   protobuf string field for Fabric Event Names.
+ - BUGFIX [FAB-16727](https://jira.hyperledger.org/browse/FAB-16727) Filters
+   containing HexEncoded numbers are now all converted to lower case upon entry,
+   which matches the storage format of all existing filters. This ensures that
+   Log Address filtering is not case-sensitive.
+ 
+Code Dependencies
+-----------------
+- Hyperledger Fabric Go SDK [1.0.0-alpha5](https://github.com/hyperledger/fabric-sdk-go/releases/tag/v1.0.0-alpha5)
+- Hyperledger Fabric [v1.4.0](https://github.com/hyperledger/fabric/releases/tag/v1.4.0).
+Though Fabric v1.4.0 is vendored in, EVMCC can be run on Fabric v1.3 and newer.
+EVMCC requires at least Go 1.10.
+- Hyperledger Burrow [v0.24.4](https://github.com/hyperledger/burrow/releases/tag/v0.24.4)
+- Minimum of Go 1.11 is required to compile Fab3.


### PR DESCRIPTION
Switched from gerrit to github for checkout.
Modules does not require GOPATH for building.
go 1.11 and up required.
We now have FABCE JIRA project.
Dep no longer used.

* [ ] Added the associated JIRA ticket number in the commit message title
* [ ] Link to the JIRA Ticket:

If you do not have a corresponding JIRA ticket, please open one in the [Fabric
JIRA](https://jira.hyperledger.org/projects/FAB/issues) and add
`fabric-chaincode-evm` as the component. In the JIRA ticket, include use
cases, design and other information useful to understanding why you are making
this pull request.

If you have any questions please feel free to ask in the #fabric-evm channel
on the [Hyperledger Chat](https://chat.hyperledger.org/channel/fabric-evm).

Thanks again for your contribution!