### PR TITLE
FAB-17053 more module updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ unit-test: gotool.ginkgo
 unit-tests: unit-test
 
 dev-test:
-	ginkgo watch -notify -randomizeAllSpecs -requireSuite -race -cover -skipPackage integration -r
+	cd fab3 && GO111MODULE=on ginkgo watch -notify -randomizeAllSpecs -requireSuite -race -cover -r
 
 linter: gotool.goimports
 	@echo "LINT: Running code checks.."

--- a/gotools.mk
+++ b/gotools.mk
@@ -44,4 +44,4 @@ gotool.counterfeiter:
 gotool.%:
 	$(eval TOOL = ${subst gotool.,,${@}})
 	@echo "Building ${go.fqp.${TOOL}} -> $(TOOL)"
-	@GOPATH=$(abspath $(GOTOOLS_GOPATH)) GOBIN=$(abspath $(GOTOOLS_BINDIR)) go get -u ${go.fqp.${TOOL}}
+	@GOPATH=$(abspath $(GOTOOLS_GOPATH)) GOBIN=$(abspath $(GOTOOLS_BINDIR)) GO111MODULE=off go get -u ${go.fqp.${TOOL}}

--- a/scripts/golinter.sh
+++ b/scripts/golinter.sh
@@ -46,7 +46,7 @@ done
 for i in "${vendoredModules[@]}"
 do
     echo ">>>Checking $i with go vet"
-    OUTPUT="$(go vet ./$i)"
+    OUTPUT="$(GO111MODULE=off go vet ./$i)"
     if [[ $OUTPUT ]]; then
         echo "The following files contain go vet errors"
         echo $OUTPUT


### PR DESCRIPTION
 - explicitly have GO111MODULE off for evmcc, and tool building
 - GO111MODULE on, and focused inside of fab3, for the dev-test target
   because ginkgo can't handle both evmcc and fab3 as modules. Most
   updates are to fab3, so I feel that this is a good trade-off.

Signed-off-by: Morgan Bauer <mbauer@us.ibm.com>


* [x] Ran the basic checks: `make basic-checks`
* [x] Ran the unit tests: `make unit-test`
* [x] Ran the integration tests: `make integration-test`
* [x] Added the associated JIRA ticket number in the commit message title
* [ ] Link to the JIRA Ticket: 