### PR TITLE
Only async

### DIFF
--- a/Fab3_Instructions.md
+++ b/Fab3_Instructions.md
@@ -26,6 +26,11 @@ Fab3 currently supports:
 - [eth_getTransactionReceipt](#eth_getTransactionReceipt)
 - [eth_getLogs](#eth_getLogs)
 - [eth_getTransactionCount](#eth_getTransactionCount)
+- [eth_newFilter](#eth_newFilter)
+- [eth_newBlockFilter](#eth_newBlockFilter)
+- [eth_uninstallFilter](#eth_uninstallFilter)
+- [eth_getFilterChanges](#eth_getFilterChanges)
+- [eth_getFilterLogs](#eth_getFilterLogs)
 
 ### net_version
 `net_version` always returns the string `66616265766d`, which is the hex encoding
@@ -368,4 +373,125 @@ curl http://127.0.0.1:5000 -X POST -H "Content-Type:application/json" -d '{
 }'
 
 {"jsonrpc":"2.0","result":"0x0","id":1}
+```
+
+### eth_newFilter
+`eth_newFilter` takes the same arguments as [`eth_getLogs`](#eth_getLogs). It returns an
+identifier to collect the log entries. The log filter is not run until
+[`eth_getFilterChanges`](#eth_getFilterChanges) is called.
+
+**Example**
+```
+curl http://127.0.0.1:5000 -X POST -H "Content-Type:application/json" -d '{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "eth_newFilter",
+  "params": [{
+    "toBlock": "latest",
+    "address": [
+      "0x6c27ec2ab7a4e81228080434d553fa198ddccfbc"
+    ],
+    "topics": [
+      [],
+      [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ]
+    ]
+  }]
+}'
+
+{"jsonrpc":"2.0","result":"0x1","id":5}
+```
+
+### eth_newBlockFilter
+`eth_newBlockFilter` creates a filter of the blocks that arrive after creation
+of the filter. An identifier is returned to refer to the filter in the future.
+
+**Example**
+```
+curl http://127.0.0.1:5000 -X POST -H "Content-Type:application/json" -d '{
+  "jsonrpc":"2.0",
+  "method": "eth_newBlockFilter",
+  "id":1,
+  "params":[]
+}'
+
+{"jsonrpc":"2.0","result":"0x2","id":1}
+```
+
+### eth_uninstallFilter
+`eth_uninstallFilter` takes a filter identifier and forgets the associated
+filter.
+
+**Example**
+```
+curl http://127.0.0.1:5000 -X POST -H "Content-Type:application/json" -d '{
+  "jsonrpc":"2.0",
+  "method": "eth_uninstallFilter",
+  "id":1,
+  "params":["0x2"]
+}'
+
+{"jsonrpc":"2.0","result":true,"id":1}
+```
+
+### eth_getFilterChanges
+`eth_getFilterChanges` takes a filter identifier and returns the output
+associated with the filter. For new block filters, that is an array of block
+hashes. For log filters, it is the log entries as if from [`eth_getLogs`](#eth_getLogs).
+
+**Example**
+```
+curl http://127.0.0.1:5000 -X POST -H "Content-Type:application/json" -d '{
+  "jsonrpc":"2.0",
+  "method": "eth_getFilterChanges",
+  "id": 6129484611666146000,
+  "params":["0x2"]
+}'
+
+{
+  "jsonrpc": "2.0",
+  "result": [
+    "0xcbe7100b09f4c5aaf2649936bf8ba65b90636ca375ec23e4a81801bffe996724",
+    "0xae3e4d4972e986d44d6bd830a2d40afa404a4e6b42b5429d2bba700b1e956e61",
+    "0x316f3cae866ae1f0c53ecce4d63378cc1ad2e3a3d7eea11315002c3e2f18d9ca",
+    "0x60d15a4cc589ac95723768a243edfa1fd432c4ea3ea83fe21938313780e8076d"
+  ],
+  "id": 6129484611666146000
+}
+```
+
+### eth_getFilterLogs
+`eth_getFilterLogs` is a deferred version of [`eth_getLogs`](#eth_getLogs) that
+does not keep track of when it was polled. The filter is run at every
+invocation. 
+
+**Example**
+```
+curl http://127.0.0.1:5000 -X POST -H "Content-Type:application/json" -d '{
+  "jsonrpc":"2.0",
+  "method": "eth_getFilterLogs",
+  "id": 8674665223082154000,
+  "params":["0x1"]
+}'
+
+{
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "address": "0xb125f5af2083c8d86e36beeabf8be0ed78028fad",
+      "topics": [
+        "0xd81ec364c58bcc9b49b6c953fc8e1f1c158ee89255bae73029133234a2936aad",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x3737373737373737373737373737373737373737373737373737373737373737"
+      ],
+      "blockNumber": "0x4",
+      "transactionHash": "0xaa8e9ffa6a49f8f99e8bb82f3711681e6638f35c408eba6772e385cb6ebee4a0",
+      "transactionIndex": "0x0",
+      "blockHash": "0xbf6deecd5d248c6d0cdab0bff79aa94bd1dc9e72a3b5b3b9e98f5d0d14145a1a",
+      "logIndex": "0x0"
+    }
+  ],
+  "id": 8674665223082154000
+}
 ```

--- a/fab3/ethservice_test.go
+++ b/fab3/ethservice_test.go
@@ -1174,7 +1174,7 @@ var _ = Describe("Ethservice", func() {
 				mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 3}}, nil)
 				sampleBlock1 := GetSampleBlock(1)
 				sampleBlock2 := GetSampleBlock(2)
-				qbs := func(b uint64, _ ...ledger.RequestOption) (*common.Block, error) {
+				mockLedgerClient.QueryBlockStub = func(b uint64, _ ...ledger.RequestOption) (*common.Block, error) {
 					logger.Debug("mockblock", b)
 					if b == 1 {
 						return sampleBlock1, nil
@@ -1184,7 +1184,6 @@ var _ = Describe("Ethservice", func() {
 						return nil, fmt.Errorf("no block available for block number %d", b)
 					}
 				}
-				mockLedgerClient.QueryBlockStub = qbs
 				mockLedgerClient.QueryBlockByHashReturns(sampleBlock2, nil)
 				logsArgs = &types.GetLogsArgs{}
 				reply = &[]types.Log{}
@@ -1340,28 +1339,269 @@ var _ = Describe("Ethservice", func() {
 		})
 	})
 
-	Describe("NewFilter & UninstallFilter", func() {
-		It("fails to find filters to uninstall when none are installed", func() {
-			var id string
-			id = "0x" + strconv.FormatUint(rand.Uint64(), 16)
-			var valid bool
-			Expect(ethservice.UninstallFilter(&http.Request{}, &id, &valid)).ToNot(HaveOccurred())
-			Expect(valid).To(BeFalse())
+	Describe("Filtering", func() {
+		Context("NewFilter & UninstallFilter", func() {
+			BeforeEach(func() {
+				By("setting the legder up to have one block")
+				mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 1}}, nil)
+			})
+
+			It("fails to find filters to uninstall when none are installed", func() {
+				id := rand.Uint64()
+				filter := types.FilterID{ID: id}
+				var valid bool
+				Expect(ethservice.UninstallFilter(&http.Request{}, &filter, &valid)).ToNot(HaveOccurred())
+				Expect(valid).To(BeFalse())
+			})
+			It("have a consistent Filter ID between invocations of NewFilter and UninstallFilter", func() {
+				var reply string
+				var x types.GetLogsArgs
+				By("Installing a filter")
+				Expect(ethservice.NewFilter(&http.Request{}, &x, &reply)).ToNot(HaveOccurred())
+				id, err := strconv.ParseUint(reply, 0, 16)
+				Expect(err).ToNot(HaveOccurred())
+				var valid bool
+				filter := types.FilterID{ID: id}
+				By("using the returned ID to uninstall a filter")
+				Expect(ethservice.UninstallFilter(&http.Request{}, &filter, &valid)).ToNot(HaveOccurred())
+				Expect(valid).To(BeTrue(), "this is the filterID we were given by NewFilter")
+				valid = false // reset to default value
+				Expect(ethservice.UninstallFilter(&http.Request{}, &filter, &valid)).ToNot(HaveOccurred())
+				Expect(valid).To(BeFalse(), "the filter has just now been removed")
+			})
 		})
-		It("has a consistent Filter ID between invocations of NewFilter and UninstallFilter", func() {
-			var reply string
-			var x types.GetLogsArgs
-			By("Installing a filter")
-			Expect(ethservice.NewFilter(&http.Request{}, &x, &reply)).ToNot(HaveOccurred())
-			_, err := strconv.ParseUint(reply, 0, 16)
-			Expect(err).ToNot(HaveOccurred())
-			var valid bool
-			By("using the returned ID to uninstall a filter")
-			Expect(ethservice.UninstallFilter(&http.Request{}, &reply, &valid)).ToNot(HaveOccurred())
-			Expect(valid).To(BeTrue(), "this is the filterID we were given by NewFilter")
-			valid = false // reset to default value
-			Expect(ethservice.UninstallFilter(&http.Request{}, &reply, &valid)).ToNot(HaveOccurred())
-			Expect(valid).To(BeFalse(), "the filter has just now been removed")
+		Context("get filter changes errors", func() {
+			It("when no filter is installed (GetFilterChanges)", func() {
+				filter := types.FilterID{ID: 0}
+				var ret []interface{}
+				Expect(ethservice.GetFilterChanges(&http.Request{}, &filter, &ret)).To(HaveOccurred())
+			})
+			It("when no filter is installed (GetFilterLogs)", func() {
+				filter := types.FilterID{ID: 0}
+				var ret []types.Log
+				Expect(ethservice.GetFilterLogs(&http.Request{}, &filter, &ret)).To(HaveOccurred())
+			})
+		})
+
+		Context("newblock filters", func() {
+			Context("when the ledger is not ok", func() {
+				It("will fail to install when we cannot establish chain height", func() {
+					mockLedgerClient.QueryInfoReturns(nil, fmt.Errorf("oh noes, cannot get block height"))
+					By("Installing a filter")
+					var reply string
+					Expect(ethservice.NewBlockFilter(&http.Request{}, nil, &reply)).To(HaveOccurred())
+				})
+				It("will fail to query when we cannot establish chain height", func() {
+					mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 1}}, nil)
+					By("Installing a filter")
+					var reply string
+					Expect(ethservice.NewBlockFilter(&http.Request{}, nil, &reply)).ToNot(HaveOccurred())
+					id, err := strconv.ParseUint(reply, 0, 16)
+					Expect(err).ToNot(HaveOccurred())
+					mockLedgerClient.QueryInfoReturns(nil, fmt.Errorf("oh noes, cannot get block height"))
+					filter := types.FilterID{ID: id}
+					var ret []interface{}
+					By("querying the filter")
+					Expect(ethservice.GetFilterChanges(&http.Request{}, &filter, &ret)).To(HaveOccurred())
+				})
+				It("fails to query when we cannot get a blocks for their hashes", func() {
+					mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 1}}, nil)
+					By("Installing a filter")
+					var reply string
+					Expect(ethservice.NewBlockFilter(&http.Request{}, nil, &reply)).ToNot(HaveOccurred())
+					id, err := strconv.ParseUint(reply, 0, 16)
+					Expect(err).ToNot(HaveOccurred())
+					filter := types.FilterID{ID: id}
+					var ret []interface{}
+					mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 2}}, nil)
+					mockLedgerClient.QueryBlockReturns(nil, fmt.Errorf("ledger can't get blocks"))
+					Expect(ethservice.GetFilterChanges(&http.Request{}, &filter, &ret)).To(HaveOccurred())
+				})
+			})
+			Context("when the ledger is ok", func() {
+				BeforeEach(func() {
+					By("setting the legder up to have one block")
+					mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 1}}, nil)
+				})
+
+				It("have a consistent Filter ID between invocations of NewBlockFilter and UninstallFilter", func() {
+					var reply string
+					By("Installing a filter")
+					Expect(ethservice.NewBlockFilter(&http.Request{}, nil, &reply)).ToNot(HaveOccurred())
+					id, err := strconv.ParseUint(reply, 0, 16)
+					Expect(err).ToNot(HaveOccurred())
+					var valid bool
+					filter := types.FilterID{ID: id}
+					By("using the returned ID to uninstall a filter")
+					Expect(ethservice.UninstallFilter(&http.Request{}, &filter, &valid)).ToNot(HaveOccurred())
+					Expect(valid).To(BeTrue(), "this is the filterID we were given by NewFilter")
+					valid = false // reset to default value
+					Expect(ethservice.UninstallFilter(&http.Request{}, &filter, &valid)).ToNot(HaveOccurred())
+					Expect(valid).To(BeFalse(), "the filter has just now been removed")
+				})
+
+				It("doesn't emit new blocks when there is no new block", func() {
+					var reply string
+					By("Installing a filter")
+					Expect(ethservice.NewBlockFilter(&http.Request{}, nil, &reply)).ToNot(HaveOccurred())
+					id, err := strconv.ParseUint(reply, 0, 16)
+					Expect(err).ToNot(HaveOccurred())
+					var ret []interface{}
+
+					var filter types.FilterID
+					filter = types.FilterID{ID: id}
+					Expect(ethservice.GetFilterChanges(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+					Expect(ret).To(BeEmpty())
+				})
+				It("emits the new block hash when there is a new block", func() {
+					var reply string
+					By("Installing a filter")
+					Expect(ethservice.NewBlockFilter(&http.Request{}, nil, &reply)).ToNot(HaveOccurred())
+					id, err := strconv.ParseUint(reply, 0, 16)
+					Expect(err).ToNot(HaveOccurred())
+					var ret []interface{}
+
+					var filter types.FilterID
+					By("put some blocks into the chain")
+					mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 3}}, nil)
+					sampleBlock1 := GetSampleBlock(1)
+					sampleBlock2 := GetSampleBlock(2)
+					mockLedgerClient.QueryBlockStub = func(b uint64, _ ...ledger.RequestOption) (*common.Block, error) {
+						logger.Debug("mockblock", b)
+						if b == 1 {
+							return sampleBlock1, nil
+						} else if b == 2 {
+							return sampleBlock2, nil
+						} else {
+							return nil, fmt.Errorf("no block available for block number %d", b)
+						}
+					}
+
+					filter = types.FilterID{ID: id}
+					Expect(ethservice.GetFilterChanges(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+					Expect(ret).To(ContainElement("0x" + hex.EncodeToString(blockHash(sampleBlock1.GetHeader()))))
+					Expect(ret).To(ContainElement("0x" + hex.EncodeToString(blockHash(sampleBlock2.GetHeader()))))
+					// now that we've called the filter, expect it not to return anything new
+					Expect(ethservice.GetFilterChanges(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+					Expect(ret).To(BeEmpty())
+				})
+			})
+		})
+
+		Context("getFilterLogs", func() {
+			BeforeEach(func() {
+				By("setting the legder up to have some blocks")
+				mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 1}}, nil)
+
+				mockLedgerClient.QueryBlockStub = func(b uint64, _ ...ledger.RequestOption) (*common.Block, error) {
+					logger.Debug("mockblock", b)
+					if b == 0 {
+						return GetSampleBlock(0), nil
+					} else if b == 1 {
+						return GetSampleBlock(1), nil
+					} else {
+						return nil, fmt.Errorf("no block available for block number %d", b)
+					}
+				}
+			})
+
+			It("errors on asking for a newBlock filter", func() {
+				var reply string
+				By("Installing a newBlock filter")
+				Expect(ethservice.NewBlockFilter(&http.Request{}, nil, &reply)).ToNot(HaveOccurred())
+				id, err := strconv.ParseUint(reply, 0, 16)
+				Expect(err).ToNot(HaveOccurred())
+
+				filter := types.FilterID{ID: id}
+
+				var ret []types.Log
+				Expect(ethservice.GetFilterLogs(&http.Request{}, &filter, &ret)).To(HaveOccurred())
+			})
+
+			It("gets logs the same way as GetLogs", func() {
+				var logsArgs *types.GetLogsArgs = &types.GetLogsArgs{FromBlock: "0"}
+				var reply string
+				var ret []types.Log
+
+				By("creating the filter with args")
+				Expect(ethservice.NewFilter(&http.Request{}, logsArgs, &reply)).ToNot(HaveOccurred())
+				id, err := strconv.ParseUint(reply, 0, 16)
+				Expect(err).ToNot(HaveOccurred())
+				filter := types.FilterID{ID: id}
+
+				By("running the previously programmed filter")
+				ret = []types.Log{}
+				Expect(ethservice.GetFilterLogs(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+				Expect(len(ret)).To(Equal(2))
+
+				By("running the filter again and getting the same amount of output")
+				ret = []types.Log{}
+				Expect(ethservice.GetFilterLogs(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+				Expect(len(ret)).To(Equal(2))
+
+				By("having new blocks show up")
+				mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 2}}, nil)
+
+				By("running the previously programmed filter")
+				ret = []types.Log{}
+				Expect(ethservice.GetFilterLogs(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+				Expect(len(ret)).To(Equal(4), "should have more blocks than before")
+
+				By("running the filter again and getting the same amount of output")
+				ret = []types.Log{}
+				Expect(ethservice.GetFilterLogs(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+				Expect(len(ret)).To(Equal(4), "should have more blocks than before")
+			})
+		})
+
+		Context("GetFilterChanges", func() {
+			BeforeEach(func() {
+				By("setting the legder up to have some blocks")
+				mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 1}}, nil)
+
+				mockLedgerClient.QueryBlockStub = func(b uint64, _ ...ledger.RequestOption) (*common.Block, error) {
+					logger.Debug("mockblock", b)
+					if b == 0 {
+						return GetSampleBlock(0), nil
+					} else if b == 1 {
+						return GetSampleBlock(1), nil
+					} else {
+						return nil, fmt.Errorf("no block available for block number %d", b)
+					}
+				}
+			})
+			It("creates a log filter, gets no logs, updates the ledger, gets logs, gets no logs", func() {
+				var logsArgs *types.GetLogsArgs = &types.GetLogsArgs{}
+				var reply string
+				var ret []interface{}
+
+				By("creating the filter with default args")
+				Expect(ethservice.NewFilter(&http.Request{}, logsArgs, &reply)).ToNot(HaveOccurred())
+				id, err := strconv.ParseUint(reply, 0, 16)
+				Expect(err).ToNot(HaveOccurred())
+				filter := types.FilterID{ID: id}
+
+				By("not getting any logs without an update")
+				ret = []interface{}{}
+				Expect(ethservice.GetFilterChanges(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+				Expect(len(ret)).To(Equal(0))
+
+				By("having new block show up")
+				mockLedgerClient.QueryInfoReturns(&fab.BlockchainInfoResponse{BCI: &common.BlockchainInfo{Height: 2}}, nil)
+
+				By("getting only the logs in the new block")
+				ret = []interface{}{}
+				Expect(ethservice.GetFilterChanges(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+				Expect(len(ret)).To(Equal(2))
+
+				By("not getting any logs without an update")
+				ret = []interface{}{}
+				Expect(ethservice.GetFilterChanges(&http.Request{}, &filter, &ret)).ToNot(HaveOccurred())
+				Expect(len(ret)).To(Equal(0))
+			})
+		})
+
+		Context("mixing calls to GetFilterLogs and GetFilterChanges", func() {
 		})
 	})
 

--- a/fab3/filters.go
+++ b/fab3/filters.go
@@ -1,0 +1,95 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fab3
+
+import (
+	"encoding/hex"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/hyperledger/fabric-chaincode-evm/fab3/types"
+)
+
+type filterEntry interface {
+	LastAccessTime() time.Time
+	Filter(s *ethService) ([]interface{}, error)
+}
+
+type logsFilter struct {
+	logArgs         *types.GetLogsArgs
+	latestBlockSeen uint64
+	lastAccessTime  time.Time
+}
+
+func (f *logsFilter) LastAccessTime() time.Time {
+	return f.lastAccessTime
+}
+
+func (f *logsFilter) Filter(s *ethService) ([]interface{}, error) {
+	s.logger.Debug("lastblockseen before filtering", f.latestBlockSeen)
+	currentLatestBlockSeen, err := s.parseBlockNum("latest")
+	if err != nil {
+		return nil, err
+	}
+	s.logger.Debug("latest blockseen", currentLatestBlockSeen)
+
+	var l []interface{}
+	if f.latestBlockSeen < currentLatestBlockSeen {
+		var logs []types.Log
+		err = s.GetLogs(nil, f.logArgs, &logs)
+		if err != nil {
+			return nil, errors.Wrap(err, "GetLogs call failed")
+		}
+		l = make([]interface{}, 0, len(logs))
+		for _, v := range logs {
+			l = append(l, v)
+		}
+	}
+	// update the filter
+	f.lastAccessTime = time.Now()
+	f.latestBlockSeen = currentLatestBlockSeen
+	s.logger.Debug("returning %d logs", len(l))
+	return l, nil
+}
+
+type newBlockFilter struct {
+	latestBlockSeen uint64
+	lastAccessTime  time.Time
+}
+
+func (f *newBlockFilter) LastAccessTime() time.Time {
+	return f.lastAccessTime
+}
+
+func (f *newBlockFilter) Filter(s *ethService) ([]interface{}, error) {
+	s.logger.Debug("lastblockseen before filtering", f.latestBlockSeen)
+	blockNumber, err := s.parseBlockNum("latest")
+	if err != nil {
+		return nil, err
+	}
+	s.logger.Debug("latest blockseen", blockNumber)
+	// iterate over blocks collecting the hashes
+	blocksToCollect := blockNumber - f.latestBlockSeen
+	// BlockFilter returns array of strings representing block numbers
+	var blocks = make([]interface{}, 0, blocksToCollect)
+	for i := blockNumber; i > f.latestBlockSeen; i-- {
+		block, err := s.ledgerClient.QueryBlock(i)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to query the ledger")
+		}
+
+		blkHeader := block.GetHeader()
+
+		blockHash := "0x" + hex.EncodeToString(blockHash(blkHeader))
+		blocks = append(blocks, blockHash)
+	}
+	// update the filter
+	f.lastAccessTime = time.Now()
+	f.latestBlockSeen = blockNumber
+	return blocks, nil
+}

--- a/fab3/mocks/mockethservice.go
+++ b/fab3/mocks/mockethservice.go
@@ -101,6 +101,32 @@ type MockEthService struct {
 	getCodeReturnsOnCall map[int]struct {
 		result1 error
 	}
+	GetFilterChangesStub        func(*http.Request, *types.FilterID, *[]interface{}) error
+	getFilterChangesMutex       sync.RWMutex
+	getFilterChangesArgsForCall []struct {
+		arg1 *http.Request
+		arg2 *types.FilterID
+		arg3 *[]interface{}
+	}
+	getFilterChangesReturns struct {
+		result1 error
+	}
+	getFilterChangesReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GetFilterLogsStub        func(*http.Request, *types.FilterID, *[]types.Log) error
+	getFilterLogsMutex       sync.RWMutex
+	getFilterLogsArgsForCall []struct {
+		arg1 *http.Request
+		arg2 *types.FilterID
+		arg3 *[]types.Log
+	}
+	getFilterLogsReturns struct {
+		result1 error
+	}
+	getFilterLogsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetLogsStub        func(*http.Request, *types.GetLogsArgs, *[]types.Log) error
 	getLogsMutex       sync.RWMutex
 	getLogsArgsForCall []struct {
@@ -153,6 +179,19 @@ type MockEthService struct {
 	getTransactionReceiptReturnsOnCall map[int]struct {
 		result1 error
 	}
+	NewBlockFilterStub        func(*http.Request, *interface{}, *string) error
+	newBlockFilterMutex       sync.RWMutex
+	newBlockFilterArgsForCall []struct {
+		arg1 *http.Request
+		arg2 *interface{}
+		arg3 *string
+	}
+	newBlockFilterReturns struct {
+		result1 error
+	}
+	newBlockFilterReturnsOnCall map[int]struct {
+		result1 error
+	}
 	NewFilterStub        func(*http.Request, *types.GetLogsArgs, *string) error
 	newFilterMutex       sync.RWMutex
 	newFilterArgsForCall []struct {
@@ -179,11 +218,11 @@ type MockEthService struct {
 	sendTransactionReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UninstallFilterStub        func(*http.Request, *string, *bool) error
+	UninstallFilterStub        func(*http.Request, *types.FilterID, *bool) error
 	uninstallFilterMutex       sync.RWMutex
 	uninstallFilterArgsForCall []struct {
 		arg1 *http.Request
-		arg2 *string
+		arg2 *types.FilterID
 		arg3 *bool
 	}
 	uninstallFilterReturns struct {
@@ -560,6 +599,110 @@ func (fake *MockEthService) GetCodeReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *MockEthService) GetFilterChanges(arg1 *http.Request, arg2 *types.FilterID, arg3 *[]interface{}) error {
+	fake.getFilterChangesMutex.Lock()
+	ret, specificReturn := fake.getFilterChangesReturnsOnCall[len(fake.getFilterChangesArgsForCall)]
+	fake.getFilterChangesArgsForCall = append(fake.getFilterChangesArgsForCall, struct {
+		arg1 *http.Request
+		arg2 *types.FilterID
+		arg3 *[]interface{}
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("GetFilterChanges", []interface{}{arg1, arg2, arg3})
+	fake.getFilterChangesMutex.Unlock()
+	if fake.GetFilterChangesStub != nil {
+		return fake.GetFilterChangesStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.getFilterChangesReturns
+	return fakeReturns.result1
+}
+
+func (fake *MockEthService) GetFilterChangesCallCount() int {
+	fake.getFilterChangesMutex.RLock()
+	defer fake.getFilterChangesMutex.RUnlock()
+	return len(fake.getFilterChangesArgsForCall)
+}
+
+func (fake *MockEthService) GetFilterChangesArgsForCall(i int) (*http.Request, *types.FilterID, *[]interface{}) {
+	fake.getFilterChangesMutex.RLock()
+	defer fake.getFilterChangesMutex.RUnlock()
+	argsForCall := fake.getFilterChangesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *MockEthService) GetFilterChangesReturns(result1 error) {
+	fake.GetFilterChangesStub = nil
+	fake.getFilterChangesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *MockEthService) GetFilterChangesReturnsOnCall(i int, result1 error) {
+	fake.GetFilterChangesStub = nil
+	if fake.getFilterChangesReturnsOnCall == nil {
+		fake.getFilterChangesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.getFilterChangesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *MockEthService) GetFilterLogs(arg1 *http.Request, arg2 *types.FilterID, arg3 *[]types.Log) error {
+	fake.getFilterLogsMutex.Lock()
+	ret, specificReturn := fake.getFilterLogsReturnsOnCall[len(fake.getFilterLogsArgsForCall)]
+	fake.getFilterLogsArgsForCall = append(fake.getFilterLogsArgsForCall, struct {
+		arg1 *http.Request
+		arg2 *types.FilterID
+		arg3 *[]types.Log
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("GetFilterLogs", []interface{}{arg1, arg2, arg3})
+	fake.getFilterLogsMutex.Unlock()
+	if fake.GetFilterLogsStub != nil {
+		return fake.GetFilterLogsStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.getFilterLogsReturns
+	return fakeReturns.result1
+}
+
+func (fake *MockEthService) GetFilterLogsCallCount() int {
+	fake.getFilterLogsMutex.RLock()
+	defer fake.getFilterLogsMutex.RUnlock()
+	return len(fake.getFilterLogsArgsForCall)
+}
+
+func (fake *MockEthService) GetFilterLogsArgsForCall(i int) (*http.Request, *types.FilterID, *[]types.Log) {
+	fake.getFilterLogsMutex.RLock()
+	defer fake.getFilterLogsMutex.RUnlock()
+	argsForCall := fake.getFilterLogsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *MockEthService) GetFilterLogsReturns(result1 error) {
+	fake.GetFilterLogsStub = nil
+	fake.getFilterLogsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *MockEthService) GetFilterLogsReturnsOnCall(i int, result1 error) {
+	fake.GetFilterLogsStub = nil
+	if fake.getFilterLogsReturnsOnCall == nil {
+		fake.getFilterLogsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.getFilterLogsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *MockEthService) GetLogs(arg1 *http.Request, arg2 *types.GetLogsArgs, arg3 *[]types.Log) error {
 	fake.getLogsMutex.Lock()
 	ret, specificReturn := fake.getLogsReturnsOnCall[len(fake.getLogsArgsForCall)]
@@ -768,6 +911,58 @@ func (fake *MockEthService) GetTransactionReceiptReturnsOnCall(i int, result1 er
 	}{result1}
 }
 
+func (fake *MockEthService) NewBlockFilter(arg1 *http.Request, arg2 *interface{}, arg3 *string) error {
+	fake.newBlockFilterMutex.Lock()
+	ret, specificReturn := fake.newBlockFilterReturnsOnCall[len(fake.newBlockFilterArgsForCall)]
+	fake.newBlockFilterArgsForCall = append(fake.newBlockFilterArgsForCall, struct {
+		arg1 *http.Request
+		arg2 *interface{}
+		arg3 *string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("NewBlockFilter", []interface{}{arg1, arg2, arg3})
+	fake.newBlockFilterMutex.Unlock()
+	if fake.NewBlockFilterStub != nil {
+		return fake.NewBlockFilterStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.newBlockFilterReturns
+	return fakeReturns.result1
+}
+
+func (fake *MockEthService) NewBlockFilterCallCount() int {
+	fake.newBlockFilterMutex.RLock()
+	defer fake.newBlockFilterMutex.RUnlock()
+	return len(fake.newBlockFilterArgsForCall)
+}
+
+func (fake *MockEthService) NewBlockFilterArgsForCall(i int) (*http.Request, *interface{}, *string) {
+	fake.newBlockFilterMutex.RLock()
+	defer fake.newBlockFilterMutex.RUnlock()
+	argsForCall := fake.newBlockFilterArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *MockEthService) NewBlockFilterReturns(result1 error) {
+	fake.NewBlockFilterStub = nil
+	fake.newBlockFilterReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *MockEthService) NewBlockFilterReturnsOnCall(i int, result1 error) {
+	fake.NewBlockFilterStub = nil
+	if fake.newBlockFilterReturnsOnCall == nil {
+		fake.newBlockFilterReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.newBlockFilterReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *MockEthService) NewFilter(arg1 *http.Request, arg2 *types.GetLogsArgs, arg3 *string) error {
 	fake.newFilterMutex.Lock()
 	ret, specificReturn := fake.newFilterReturnsOnCall[len(fake.newFilterArgsForCall)]
@@ -872,12 +1067,12 @@ func (fake *MockEthService) SendTransactionReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *MockEthService) UninstallFilter(arg1 *http.Request, arg2 *string, arg3 *bool) error {
+func (fake *MockEthService) UninstallFilter(arg1 *http.Request, arg2 *types.FilterID, arg3 *bool) error {
 	fake.uninstallFilterMutex.Lock()
 	ret, specificReturn := fake.uninstallFilterReturnsOnCall[len(fake.uninstallFilterArgsForCall)]
 	fake.uninstallFilterArgsForCall = append(fake.uninstallFilterArgsForCall, struct {
 		arg1 *http.Request
-		arg2 *string
+		arg2 *types.FilterID
 		arg3 *bool
 	}{arg1, arg2, arg3})
 	fake.recordInvocation("UninstallFilter", []interface{}{arg1, arg2, arg3})
@@ -898,7 +1093,7 @@ func (fake *MockEthService) UninstallFilterCallCount() int {
 	return len(fake.uninstallFilterArgsForCall)
 }
 
-func (fake *MockEthService) UninstallFilterArgsForCall(i int) (*http.Request, *string, *bool) {
+func (fake *MockEthService) UninstallFilterArgsForCall(i int) (*http.Request, *types.FilterID, *bool) {
 	fake.uninstallFilterMutex.RLock()
 	defer fake.uninstallFilterMutex.RUnlock()
 	argsForCall := fake.uninstallFilterArgsForCall[i]
@@ -941,6 +1136,10 @@ func (fake *MockEthService) Invocations() map[string][][]interface{} {
 	defer fake.getBlockByNumberMutex.RUnlock()
 	fake.getCodeMutex.RLock()
 	defer fake.getCodeMutex.RUnlock()
+	fake.getFilterChangesMutex.RLock()
+	defer fake.getFilterChangesMutex.RUnlock()
+	fake.getFilterLogsMutex.RLock()
+	defer fake.getFilterLogsMutex.RUnlock()
 	fake.getLogsMutex.RLock()
 	defer fake.getLogsMutex.RUnlock()
 	fake.getTransactionByHashMutex.RLock()
@@ -949,6 +1148,8 @@ func (fake *MockEthService) Invocations() map[string][][]interface{} {
 	defer fake.getTransactionCountMutex.RUnlock()
 	fake.getTransactionReceiptMutex.RLock()
 	defer fake.getTransactionReceiptMutex.RUnlock()
+	fake.newBlockFilterMutex.RLock()
+	defer fake.newBlockFilterMutex.RUnlock()
 	fake.newFilterMutex.RLock()
 	defer fake.newFilterMutex.RUnlock()
 	fake.sendTransactionMutex.RLock()

--- a/fab3/types/types.go
+++ b/fab3/types/types.go
@@ -14,6 +14,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -48,11 +49,28 @@ type GetLogsArgs struct {
 	BlockHash string        `json:"blockHash,omitempty"`
 }
 
+type FilterID struct {
+	ID uint64
+}
+
 type AddressFilter []string // 20 Byte Addresses, OR'd together
 
 type TopicFilter []string // 32 Byte Topics, OR'd together
 
 type TopicsFilter []TopicFilter // TopicFilter, AND'd together
+
+func (id *FilterID) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	fid, err := strconv.ParseUint(strip0x(s), 16, 64)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse filter id")
+	}
+	id.ID = fid
+	return nil
+}
 
 func (gla *GetLogsArgs) UnmarshalJSON(data []byte) error {
 	type inputGetLogsArgs struct {

--- a/fab3/types/types_test.go
+++ b/fab3/types/types_test.go
@@ -249,3 +249,13 @@ var _ = Describe("Types JSON Marshaling and Unmarshaling", func() {
 			[]byte(`{"number":"", "parentHash":"", "hash":"", "gasLimit":"0x0", "transactions":["0x12345678"]}`)),
 	)
 })
+
+var _ = Describe("FilterID UnmarshalJSON", func() {
+	It("takes the right stuff", func() {
+		var expected FilterID
+		bytes := []byte(`"0x16"`)
+		err := json.Unmarshal(bytes, &expected)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(expected.ID).To(Equal(uint64(22)))
+	})
+})

--- a/integration/fab3/fab3_suite_test.go
+++ b/integration/fab3/fab3_suite_test.go
@@ -20,6 +20,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/tedsuo/ifrit"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestFab3(t *testing.T) {
@@ -91,6 +93,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 }, func(payload []byte) {
 	err := json.Unmarshal(payload, &components)
 	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = BeforeEach(func() {
+	core := zapcore.NewCore(zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()), zapcore.AddSync(GinkgoWriter), zap.DebugLevel)
+	rawLogger := zap.New(core)
+	zap.ReplaceGlobals(rawLogger)
 })
 
 var _ = SynchronizedAfterSuite(func() {

--- a/integration/fab3/web3_e2e_test.js
+++ b/integration/fab3/web3_e2e_test.js
@@ -226,3 +226,4 @@ var user2Address = process.argv[3]
 TestVotingContract(user1Address, user2Address)
 TestInstructorContractEvents(user1Address)
 console.log("Finished Web3 Tests")
+process.exit(0)

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -50,7 +50,7 @@ main() {
 
     echo "Building CCENV image"
     pushd ${FABRIC_DIR}
-        make ccenv
+        make ccenv CHAINTOOL_URL='https://hyperledger.jfrog.io/hyperledger/fabric-maven/org/hyperledger/fabric-chaintool/$(CHAINTOOL_RELEASE)/fabric-chaintool-$(CHAINTOOL_RELEASE).jar'
     popd
 
     echo "Running integration tests..."


### PR DESCRIPTION
begin of cleaned up version 

I see one more split I can make with the FilterID type.

can't run counterfeiter, which prevents me from updating the types for filterLogs, which leads to some extra code.
