### PR TITLE
[FABCE-147] Fix mock generation for fab3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,5 +103,5 @@ bin/evmcc:
 # Requires go v1.11+
 .PHONY:
 update-mocks: gotool.counterfeiter
-	go generate ./fab3/
 	counterfeiter -o evmcc/mocks/mockstub.go --fake-name MockStub evmcc/vendor/github.com/hyperledger/fabric/core/chaincode/shim/interfaces.go ChaincodeStubInterface
+	cd fab3 && GO111MODULE=on go generate .


### PR DESCRIPTION
 - GO111MODULE needs to be set to `on` for counterfeiter to generate
 mocks for fab3

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>

* [x] Ran the basic checks: `make basic-checks`
* [x] Ran the unit tests: `make unit-test`
* [x] Ran the integration tests: `make integration-test`
* [x] Added the associated JIRA ticket number in the commit message title
* [x] Link to the JIRA Ticket: https://jira.hyperledger.org/browse/FABCE-147
