### PR TITLE
FABCE-148 override chaintool location

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -50,7 +50,7 @@ main() {
 
     echo "Building CCENV image"
     pushd ${FABRIC_DIR}
-        make ccenv
+        make ccenv CHAINTOOL_URL='https://hyperledger.jfrog.io/hyperledger/fabric-maven/org/hyperledger/fabric-chaintool/$(CHAINTOOL_RELEASE)/fabric-chaintool-$(CHAINTOOL_RELEASE).jar'
     popd
 
     echo "Running integration tests..."


### PR DESCRIPTION
Due to the deprecation of the nexus servers, all depenedencies, including the chaintool, are now in a new location.

Change-Id: I5a1558e4c689c24d495a0e09834386bb2c087f90
Signed-off-by: Morgan Bauer <mbauer@us.ibm.com>


This is a workaround until we update to fabric 2.0 dependencies.